### PR TITLE
Only save the mutualfunds which we have as commodities

### DIFF
--- a/hledger_get-indian-mf-prices.sh
+++ b/hledger_get-indian-mf-prices.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
+
+hledger stats | grep -o '\bINF\w*' > /tmp/hledger-commodities
+
 curl -s https://www.amfiindia.com/spages/NAVAll.txt | \
-grep -E "INF677K01023|[ISIN]|[symbol]" | \
+grep -f /tmp/hledger-commodities | \
 tr -d '\r' | \
 awk -F";" '{printf("\"%s\" %s ",$2,"₹"$5);system("date -d "$8" +%Y-%m-%d");}' | \
 awk '{print "P",$3,$1,$2 }' | \


### PR DESCRIPTION
This is currently using ledger instead of hledger as the latter doesn't
provide a 'commodities' command, and requires parsing the 'stats'
command instead.